### PR TITLE
Add Obsidian theme

### DIFF
--- a/Obsidian theme/1.0.0/plugin.edn
+++ b/Obsidian theme/1.0.0/plugin.edn
@@ -1,0 +1,6 @@
+{:name "Obsidian theme"
+ :version "1.0.0"
+ :author "Pablo Ariel Mayobre"
+ :source "https://github.com/Positive07/obsidian-theme-lighttable"
+ :desc "Dark theme based on Notepad++ Obsidian theme, with some tweaks to look nicer!"
+ :behaviors "obsidian.behaviors"}


### PR DESCRIPTION
A dark theme for LightTable, based on Notepad++ Obsidian theme. Uses Niflheim as a base.

Tested on LightTable 0.8.1 in Windows 7